### PR TITLE
feat: Adiciona filtros booleanos à listagem de produtos

### DIFF
--- a/backend/src/main/java/br/com/senai/desafio/tech_challenge/controller/ProductController.java
+++ b/backend/src/main/java/br/com/senai/desafio/tech_challenge/controller/ProductController.java
@@ -42,14 +42,17 @@ public class ProductController {
     }
     @GetMapping
     public ResponseEntity<PaginatedResponseDTO<ProductResponseDTO>> listProducts(
-            // A anotação @PageableDefault define os valores padrão para paginação e ordenação.
             @PageableDefault(size = 10, sort = "name") Pageable pageable,
-            // @RequestParam captura os parâmetros da URL. 'required = false' torna-os opcionais.
             @RequestParam(required = false) String search,
             @RequestParam(required = false) BigDecimal minPrice,
-            @RequestParam(required = false) BigDecimal maxPrice
+            @RequestParam(required = false) BigDecimal maxPrice,
+            @RequestParam(required = false) Boolean hasDiscount,
+            @RequestParam(required = false) Boolean onlyOutOfStock,
+            @RequestParam(required = false) Boolean withCouponApplied
     ) {
-        PaginatedResponseDTO<ProductResponseDTO> response = productService.listProducts(pageable, search, minPrice, maxPrice);
+        PaginatedResponseDTO<ProductResponseDTO> response = productService.listProducts(
+                pageable, search, minPrice, maxPrice, hasDiscount, onlyOutOfStock, withCouponApplied
+        );
         return ResponseEntity.ok(response);
     }
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/br/com/senai/desafio/tech_challenge/model/Product.java
+++ b/backend/src/main/java/br/com/senai/desafio/tech_challenge/model/Product.java
@@ -11,11 +11,26 @@ import org.hibernate.annotations.Where;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.Where;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
 
 @Entity
 @Table(name = "products")
-@SQLDelete(sql = "UPDATE products SET deleted_at = NOW() WHERE id = ?") // Define o comando para soft delete
-@Where(clause = "deleted_at IS NULL") // Garante que queries sempre filtrem os deletados
+@SQLDelete(sql = "UPDATE products SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -38,14 +53,17 @@ public class Product {
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal price;
 
-    @CreationTimestamp // Hibernate preenche com a data/hora de criação
+    @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
-    @UpdateTimestamp // Hibernate preenche com a data/hora da última atualização
+    @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
     @Column(name = "deleted_at")
     private Instant deletedAt;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductDiscount> discounts;
 }

--- a/backend/src/main/java/br/com/senai/desafio/tech_challenge/service/ProductService.java
+++ b/backend/src/main/java/br/com/senai/desafio/tech_challenge/service/ProductService.java
@@ -9,10 +9,8 @@ public interface ProductService {
     ProductResponseDTO createProduct(ProductRequestDTO productRequestDTO);
     ProductResponseDTO getProductById(Long id);
     PaginatedResponseDTO<ProductResponseDTO> listProducts(
-            Pageable pageable,
-            String search,
-            BigDecimal minPrice,
-            BigDecimal maxPrice
+            Pageable pageable, String search, BigDecimal minPrice, BigDecimal maxPrice,
+            Boolean hasDiscount, Boolean onlyOutOfStock, Boolean withCouponApplied
     );
     void deleteProduct(Long id);
     ProductResponseDTO restoreProduct(Long id);

--- a/backend/src/main/java/br/com/senai/desafio/tech_challenge/service/ProductServiceImpl.java
+++ b/backend/src/main/java/br/com/senai/desafio/tech_challenge/service/ProductServiceImpl.java
@@ -58,32 +58,27 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public PaginatedResponseDTO<ProductResponseDTO> listProducts(
-            Pageable pageable, String search, BigDecimal minPrice, BigDecimal maxPrice) {
+            Pageable pageable, String search, BigDecimal minPrice, BigDecimal maxPrice,
+            Boolean hasDiscount, Boolean onlyOutOfStock, Boolean withCouponApplied) {
 
-        Specification<Product> spec = Specification.where(null);
-        if (search != null && !search.isEmpty()) {
-            spec = spec.and(ProductSpecification.hasText(search));
-        }
-        if (minPrice != null) {
-            spec = spec.and(ProductSpecification.hasMinPrice(minPrice));
-        }
-        if (maxPrice != null) {
-            spec = spec.and(ProductSpecification.hasMaxPrice(maxPrice));
-        }
+        Specification<Product> spec = Specification.where(ProductSpecification.hasText(search))
+                .and(ProductSpecification.hasMinPrice(minPrice))
+                .and(ProductSpecification.hasMaxPrice(maxPrice))
+                .and(ProductSpecification.hasDiscount(hasDiscount))
+                .and(ProductSpecification.isOutOfStock(onlyOutOfStock))
+                .and(ProductSpecification.withCouponApplied(withCouponApplied));
 
         Page<Product> productPage = productRepository.findAll(spec, pageable);
 
         var productDTOs = productPage.getContent().stream()
                 .map(this::mapToProductResponseDTO)
                 .collect(Collectors.toList());
-
         MetaDTO meta = MetaDTO.builder()
                 .page(productPage.getNumber())
                 .limit(productPage.getSize())
                 .totalItems(productPage.getTotalElements())
                 .totalPages(productPage.getTotalPages())
                 .build();
-
         return new PaginatedResponseDTO<>(productDTOs, meta);
     }
 


### PR DESCRIPTION
Este PR finaliza os requisitos de listagem do backend ao adicionar os seguintes filtros booleanos ao endpoint `GET /products`:
- `hasDiscount`
- `onlyOutOfStock`
- `withCouponApplied`

A lógica foi implementada na `ProductSpecification` e testada manualmente via Swagger. 